### PR TITLE
Ressources folder: update schema

### DIFF
--- a/resources/resourcemanager_folders.go
+++ b/resources/resourcemanager_folders.go
@@ -14,6 +14,7 @@ func ResourceManagerFolders() *schema.Table {
 		Resolver:    fetchResourceManagerFolders,
 		Multiplex:   client.MultiplexBy(client.Folders),
 		IgnoreError: client.IgnoreErrorHandler,
+		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"cloud_id", "id"}},
 		Columns: []schema.Column{
 			{
 				Name:            "id",
@@ -41,10 +42,10 @@ func ResourceManagerFolders() *schema.Table {
 				Resolver:    schema.PathResolver("Description"),
 			},
 			{
-				Name:        "organization_id",
+				Name:        "cloud_id",
 				Type:        schema.TypeString,
 				Description: "ID of the organization that the folder belongs to.",
-				Resolver:    schema.PathResolver("OrganizationId"),
+				Resolver:    schema.PathResolver("CloudId"),
 			},
 		},
 	}


### PR DESCRIPTION
Hello Guys,

We use your provider and we had a lot of issue regarding ressources folder. Every time, we had some duplicate entry on id.
After digging and reading this https://cloud.yandex.com/en/docs/resource-manager/api-ref/grpc/folder_service, ResourceManager.Folder().Get returns cloud id and not organization_id.
`eg of return: id:"xxxx" cloud_id:"xxxxx" created_at:{seconds:1622448016} name:"xxx-xxx" status:ACTIVE`

Also add pk on cloud_id, id instead of cq_id.


Thanks.